### PR TITLE
feat: NavMesh 기반 동작으로 변경

### DIFF
--- a/Assets/Prefabs/Cubes/WaterCube.prefab
+++ b/Assets/Prefabs/Cubes/WaterCube.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 453597132569979584}
   - component: {fileID: 5342009663094026823}
   - component: {fileID: 1836395638657824735}
+  - component: {fileID: -8370386561071866988}
   m_Layer: 0
   m_Name: WaterCube
   m_TagString: Untagged
@@ -112,3 +113,19 @@ MeshRenderer:
   m_SortingOrder: 0
   m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!208 &-8370386561071866988
+NavMeshObstacle:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1526672358175396467}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Shape: 1
+  m_Extents: {x: 0.5, y: 1.5, z: 0.5}
+  m_MoveThreshold: 0.1
+  m_Carve: 1
+  m_CarveOnlyStationary: 1
+  m_Center: {x: 0, y: 0, z: 0}
+  m_TimeToStationary: 0.5

--- a/Assets/Scenes/MainGameScene.unity
+++ b/Assets/Scenes/MainGameScene.unity
@@ -1705,6 +1705,28 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::PassiveAnimal
   Asset: {fileID: 11400000, guid: f157176ad8bc0e0409f6e3fab8697e84, type: 2}
+--- !u!195 &294875805
+NavMeshAgent:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 294875795}
+  m_Enabled: 1
+  m_AgentTypeID: 0
+  m_Radius: 0.5
+  m_Speed: 3.5
+  m_Acceleration: 8
+  avoidancePriority: 50
+  m_AngularSpeed: 120
+  m_StoppingDistance: 0
+  m_AutoTraverseOffMeshLink: 1
+  m_AutoBraking: 1
+  m_AutoRepath: 1
+  m_Height: 2
+  m_BaseOffset: 0
+  m_WalkableMask: 4294967295
+  m_ObstacleAvoidanceType: 2
 --- !u!1 &299019895
 GameObject:
   m_ObjectHideFlags: 0
@@ -2596,7 +2618,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2354719749153065472, guid: 1b48a49fd5a4e2f42a5767259aeb17af, type: 3}
       propertyPath: m_SizeDelta.x
-      value: -131.76917
+      value: -100.85864
       objectReference: {fileID: 0}
     - target: {fileID: 3797442257898432797, guid: 1b48a49fd5a4e2f42a5767259aeb17af, type: 3}
       propertyPath: m_Pivot.x
@@ -2704,7 +2726,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8914082914844691740, guid: 1b48a49fd5a4e2f42a5767259aeb17af, type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.97117877
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8914082914844691740, guid: 1b48a49fd5a4e2f42a5767259aeb17af, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.05811966
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -3800,6 +3826,28 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::HostileAnimal
   Asset: {fileID: 11400000, guid: b45481e233c98c64398f1a97d10fe79b, type: 2}
+--- !u!195 &669233791
+NavMeshAgent:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 669233781}
+  m_Enabled: 1
+  m_AgentTypeID: 0
+  m_Radius: 0.5
+  m_Speed: 3.5
+  m_Acceleration: 8
+  avoidancePriority: 50
+  m_AngularSpeed: 120
+  m_StoppingDistance: 0
+  m_AutoTraverseOffMeshLink: 1
+  m_AutoBraking: 1
+  m_AutoRepath: 1
+  m_Height: 2
+  m_BaseOffset: 0
+  m_WalkableMask: 4294967295
+  m_ObstacleAvoidanceType: 2
 --- !u!1 &693122422
 GameObject:
   m_ObjectHideFlags: 0
@@ -4154,6 +4202,27 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &843614301 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5826349668619421509, guid: 4c12b99cc12ad9b47b7623c1577f634f, type: 3}
+  m_PrefabInstance: {fileID: 1256453377}
+  m_PrefabAsset: {fileID: 0}
+--- !u!208 &843614306
+NavMeshObstacle:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 843614301}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Shape: 1
+  m_Extents: {x: 2.5, y: 1.1320001, z: 2.5}
+  m_MoveThreshold: 0.1
+  m_Carve: 1
+  m_CarveOnlyStationary: 1
+  m_Center: {x: 0, y: 1.1320001, z: 0}
+  m_TimeToStationary: 0.5
 --- !u!1 &878268770
 GameObject:
   m_ObjectHideFlags: 0
@@ -4297,7 +4366,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5972542745036174202, guid: 7829ffac68ffe624cb6f2fdd3f39003d, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.49999997
+      value: 0.63
       objectReference: {fileID: 0}
     - target: {fileID: 5972542745036174202, guid: 7829ffac68ffe624cb6f2fdd3f39003d, type: 3}
       propertyPath: m_LocalPosition.z
@@ -4346,6 +4415,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 5972542745036174205, guid: 7829ffac68ffe624cb6f2fdd3f39003d, type: 3}
       insertIndex: -1
       addedObject: {fileID: 669233786}
+    - targetCorrespondingSourceObject: {fileID: 5972542745036174205, guid: 7829ffac68ffe624cb6f2fdd3f39003d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 669233791}
   m_SourcePrefab: {fileID: 100100000, guid: 7829ffac68ffe624cb6f2fdd3f39003d, type: 3}
 --- !u!1001 &916082899
 PrefabInstance:
@@ -4361,7 +4433,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7100625709073867657, guid: 50bf0d89f095438448e61792c16f8bef, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.5
+      value: 0.63000005
       objectReference: {fileID: 0}
     - target: {fileID: 7100625709073867657, guid: 50bf0d89f095438448e61792c16f8bef, type: 3}
       propertyPath: m_LocalPosition.z
@@ -4414,6 +4486,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 7100625709073867658, guid: 50bf0d89f095438448e61792c16f8bef, type: 3}
       insertIndex: -1
       addedObject: {fileID: 294875800}
+    - targetCorrespondingSourceObject: {fileID: 7100625709073867658, guid: 50bf0d89f095438448e61792c16f8bef, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 294875805}
   m_SourcePrefab: {fileID: 100100000, guid: 50bf0d89f095438448e61792c16f8bef, type: 3}
 --- !u!1 &928225308
 GameObject:
@@ -5426,7 +5501,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9161587131229490087, guid: 4c12b99cc12ad9b47b7623c1577f634f, type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 9212994427324105674, guid: 4c12b99cc12ad9b47b7623c1577f634f, type: 3}
       propertyPath: m_LocalPosition.x
@@ -5448,7 +5523,10 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 1267383275690838446, guid: 4c12b99cc12ad9b47b7623c1577f634f, type: 3}
       insertIndex: -1
       addedObject: {fileID: 33312830417726898}
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5826349668619421509, guid: 4c12b99cc12ad9b47b7623c1577f634f, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 843614306}
   m_SourcePrefab: {fileID: 100100000, guid: 4c12b99cc12ad9b47b7623c1577f634f, type: 3}
 --- !u!1 &1363707290
 GameObject:
@@ -5641,7 +5719,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2041246020272525057, guid: edf2fc2f97106904ba1ec958e84c5181, type: 3}
       propertyPath: m_SizeDelta.x
-      value: -66.974304
+      value: -41.215515
       objectReference: {fileID: 0}
     - target: {fileID: 2041246020272525057, guid: edf2fc2f97106904ba1ec958e84c5181, type: 3}
       propertyPath: m_SizeDelta.y
@@ -5709,7 +5787,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5416019533411765915, guid: edf2fc2f97106904ba1ec958e84c5181, type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.97117877
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5416019533411765915, guid: edf2fc2f97106904ba1ec958e84c5181, type: 3}
       propertyPath: m_AnchorMax.y
@@ -5717,7 +5795,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5416019533411765915, guid: edf2fc2f97106904ba1ec958e84c5181, type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0
+      value: 0.05811966
       objectReference: {fileID: 0}
     - target: {fileID: 5416019533411765915, guid: edf2fc2f97106904ba1ec958e84c5181, type: 3}
       propertyPath: m_AnchorMin.y
@@ -7367,7 +7445,7 @@ MeshRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1923272632}
-  m_Enabled: 1
+  m_Enabled: 0
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
@@ -7426,7 +7504,7 @@ Transform:
   m_GameObject: {fileID: 1923272632}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.4, z: 0}
+  m_LocalPosition: {x: 0, y: 0.5, z: 0}
   m_LocalScale: {x: 20, y: 1, z: 20}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -8033,6 +8111,22 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 770048404654511864, guid: fda97def55dc9e544bfdf3ae3116cbe3, type: 3}
   m_PrefabInstance: {fileID: 6383767056819419670}
   m_PrefabAsset: {fileID: 0}
+--- !u!208 &33312830417726901
+NavMeshObstacle:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1367997658600530}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Shape: 1
+  m_Extents: {x: 3.0890002, y: 2.736, z: 3.0890002}
+  m_MoveThreshold: 0.1
+  m_Carve: 1
+  m_CarveOnlyStationary: 1
+  m_Center: {x: 0, y: 2.736, z: 0}
+  m_TimeToStationary: 0.5
 --- !u!1001 &56650075042092299
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8111,7 +8205,7 @@ PrefabInstance:
       objectReference: {fileID: 1948195616}
     - target: {fileID: 6206606302358517628, guid: 2c58099b044771a4c940001a040b567d, type: 3}
       propertyPath: useJoystick
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -9453,6 +9547,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 1237102807493896314, guid: fda97def55dc9e544bfdf3ae3116cbe3, type: 3}
       insertIndex: -1
       addedObject: {fileID: 33312830417726895}
+    - targetCorrespondingSourceObject: {fileID: 1237102807493896314, guid: fda97def55dc9e544bfdf3ae3116cbe3, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 33312830417726901}
   m_SourcePrefab: {fileID: 100100000, guid: fda97def55dc9e544bfdf3ae3116cbe3, type: 3}
 --- !u!224 &6517777644932504215
 RectTransform:

--- a/Assets/Scripts/Data/Animal/Animal.cs
+++ b/Assets/Scripts/Data/Animal/Animal.cs
@@ -46,6 +46,8 @@ public abstract class Animal : MonoBehaviour, IDefender, IDroppable
         Animator = GetComponent<Animator>();
         Agent = GetComponent<NavMeshAgent>();
         Agent.speed = Asset.Data.MoveSpeed;
+        Agent.acceleration = 100f;
+        Agent.updateRotation = false;
         SetAnimatorController();
 
         CurrentState = AnimalState.Idle;
@@ -72,7 +74,6 @@ public abstract class Animal : MonoBehaviour, IDefender, IDroppable
         stateTimer -= Time.deltaTime;
         if (stateTimer <= 0f)
         {
-            // NavMesh 위의 랜덤 지점으로 이동
             Vector3 randomDir = new Vector3(
                 Random.Range(-1f, 1f),
                 0f,
@@ -83,7 +84,6 @@ public abstract class Animal : MonoBehaviour, IDefender, IDroppable
             if (NavMesh.SamplePosition(targetPos, out NavMeshHit hit, 5f, NavMesh.AllAreas))
                 Agent.SetDestination(hit.position);
 
-            stateTimer = Random.Range(Asset.RoamDurationMin, Asset.RoamDurationMax);
             CurrentState = AnimalState.Roam;
         }
     }
@@ -91,12 +91,20 @@ public abstract class Animal : MonoBehaviour, IDefender, IDroppable
     private void UpdateRoam()
     {
         if (Agent.velocity.sqrMagnitude > 0.01f)
-            transform.forward = new Vector3(Agent.velocity.x, 0f, Agent.velocity.z).normalized;
-
-        stateTimer -= Time.deltaTime;
-        if (stateTimer <= 0f)
         {
-            Agent.ResetPath();
+            Quaternion targetRot = Quaternion.LookRotation(
+                new Vector3(Agent.velocity.x, 0f, Agent.velocity.z)
+            );
+            transform.rotation = Quaternion.Slerp(
+                transform.rotation,
+                targetRot,
+                10f * Time.deltaTime
+            );
+        }
+
+        // 목적지에 도착하면 Idle로
+        if (!Agent.pathPending && Agent.remainingDistance <= Agent.stoppingDistance)
+        {
             stateTimer = Random.Range(Asset.IdleDurationMin, Asset.IdleDurationMax);
             CurrentState = AnimalState.Idle;
         }

--- a/Assets/Scripts/Data/Animal/AnimalAsset.cs
+++ b/Assets/Scripts/Data/Animal/AnimalAsset.cs
@@ -8,8 +8,6 @@ public class AnimalAsset : ScriptableObject
     [Header("Idle / Roam")]
     public float IdleDurationMin = 2f;
     public float IdleDurationMax = 4f;
-    public float RoamDurationMin = 3f;
-    public float RoamDurationMax = 5f;
 
     [HideInInspector]
     public AnimalData Data;

--- a/Assets/Scripts/Data/Animal/HostileAnimal.cs
+++ b/Assets/Scripts/Data/Animal/HostileAnimal.cs
@@ -36,16 +36,28 @@ public class HostileAnimal : Animal, IAttacker
 
     private void UpdateChase()
     {
-        Vector3 dir = (PlayerTransform.position - transform.position).normalized;
-        dir.y = 0f;
-        transform.forward = dir;
-        transform.position += dir * Asset.Data.MoveSpeed * Time.deltaTime;
+        Agent.SetDestination(PlayerTransform.position);
+
+        if (Agent.velocity.sqrMagnitude > 0.01f)
+        {
+            Quaternion targetRot = Quaternion.LookRotation(
+                new Vector3(Agent.velocity.x, 0f, Agent.velocity.z)
+            );
+            transform.rotation = Quaternion.Slerp(
+                transform.rotation,
+                targetRot,
+                10f * Time.deltaTime
+            );
+        }
 
         if (
             Vector3.Distance(transform.position, PlayerTransform.position)
             <= HostileAsset.EnterAttackRange
         )
+        {
+            Agent.ResetPath();
             CurrentState = AnimalState.Attack;
+        }
     }
 
     private void UpdateAttack()

--- a/Assets/Scripts/Data/Animal/PassiveAnimal.cs
+++ b/Assets/Scripts/Data/Animal/PassiveAnimal.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.AI;
 
 public class PassiveAnimal : Animal
 {
@@ -16,14 +17,28 @@ public class PassiveAnimal : Animal
 
     private void UpdateFlee()
     {
-        Vector3 dirFromPlayer = (transform.position - PlayerTransform.position).normalized;
-        MoveDirection = new Vector3(dirFromPlayer.x, 0f, dirFromPlayer.z).normalized;
-        transform.forward = MoveDirection;
-        transform.position += MoveDirection * Asset.Data.MoveSpeed * Time.deltaTime;
+        Vector3 fleePos =
+            transform.position + (transform.position - PlayerTransform.position).normalized * 10f;
+
+        if (NavMesh.SamplePosition(fleePos, out NavMeshHit hit, 5f, NavMesh.AllAreas))
+            Agent.SetDestination(hit.position);
+
+        if (Agent.velocity.sqrMagnitude > 0.01f)
+        {
+            Quaternion targetRot = Quaternion.LookRotation(
+                new Vector3(Agent.velocity.x, 0f, Agent.velocity.z)
+            );
+            transform.rotation = Quaternion.Slerp(
+                transform.rotation,
+                targetRot,
+                10f * Time.deltaTime
+            );
+        }
 
         fleeTimer -= Time.deltaTime;
         if (fleeTimer <= 0f)
         {
+            Agent.ResetPath();
             ResetStateTimer();
             CurrentState = AnimalState.Idle;
         }


### PR DESCRIPTION
Map 생성, 동물 이동
- Plane 깔아두고 bake 한 뒤 Mesh Rederer 지움
- 자원과 건물들한테 NavMesh Obstacle 할당 후 Carve 체크해서 런타임 활성화
- 물도 장애물 처리해서 못가는 판정
- 동물 이동도 NavMesh 기반으로 변경
- 동물이 움직일때 바라보는 방향은 따로 처리
- 동물 Roam -> Idle 전환을 시간 단위가 아닌 목적지 도착 여부로 판단
close #95 
close #96 